### PR TITLE
Revert problematic commit and restore linter configuration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --ignore-engines
+
+      - name: Run linter
+        run: yarn lint
+
+      - name: Check formatting
+        run: yarn format:check

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules
+build
+public
+yarn.lock
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -21,13 +21,30 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx --max-warnings 0",
+    "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
+    "format:fix": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "eject": "react-scripts eject"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.1",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-config-react-app": "^7.0.1",
+    "prettier": "^3.3.3"
   },
   "eslintConfig": {
     "extends": [
       "react-app",
-      "react-app/jest"
+      "react-app/jest",
+      "prettier"
     ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "all",
+    "printWidth": 80,
+    "tabWidth": 2,
+    "semi": true
   },
   "browserslist": {
     "production": [

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,9 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
-import App from "./App";
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import App from './App';
 
-test("renders game container", () => {
+test('renders game container', () => {
   render(<App />);
-  const gameContainer = screen.getByRole("textbox");
+  const gameContainer = screen.getByRole('textbox');
   expect(gameContainer).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import "./App.css";
-import Game from "./Game";
+import React from 'react';
+import './App.css';
+import Game from './Game';
 
 function App() {
   return (

--- a/src/Game/Ayah.tsx
+++ b/src/Game/Ayah.tsx
@@ -1,14 +1,22 @@
-import { ReactNode } from "react";
-import Word from "./Word";
-import { WordProps } from "./Word";
+import { ReactNode } from 'react';
+import Word from './Word';
+import { WordProps } from './Word';
 
 export type AyahProps = {
   words: WordProps[];
+  translation?: string;
+  number?: number;
 };
 
-export default function Ayah({ words }: AyahProps) {
+export default function Ayah({ words, translation, number }: AyahProps) {
   const wordsDOM = words
-    .map<ReactNode>((word, index) => <Word key={index} text={word.text}></Word>)
-    .reduce((accu, curr) => [accu, " ", curr]);
-  return <div>{wordsDOM}</div>;
+    .map<ReactNode>((word, index) => (
+      <Word key={index} text={word.text} translation={word.translation}></Word>
+    ))
+    .reduce((accu, curr) => (accu === null ? [curr] : [accu, ' ', curr]), null);
+  return (
+    <div title={translation}>
+      {wordsDOM} {number && <span>({number})</span>}
+    </div>
+  );
 }

--- a/src/Game/AyahDisplay.tsx
+++ b/src/Game/AyahDisplay.tsx
@@ -1,13 +1,18 @@
-import Ayah from "./Ayah";
-import { AyahProps } from "./Ayah";
+import Ayah from './Ayah';
+import { AyahData } from '../types/surah';
 
 export type AyahDisplayProps = {
-  ayahs: AyahProps[];
+  ayahs: AyahData[];
 };
 
 export default function AyahDisplay({ ayahs }: AyahDisplayProps) {
   const ayahsDOM = ayahs.map((ayah, index) => (
-    <Ayah key={index} words={ayah.words}></Ayah>
+    <Ayah
+      key={index}
+      words={ayah.words}
+      translation={ayah.translation}
+      number={ayah.number}
+    ></Ayah>
   ));
   return <div>{ayahsDOM}</div>;
 }

--- a/src/Game/Game.tsx
+++ b/src/Game/Game.tsx
@@ -1,61 +1,14 @@
-import AyahDisplay from "./AyahDisplay";
-import Input from "./Input";
+import AyahDisplay from './AyahDisplay';
+import Input from './Input';
+import { fatihah } from '../data/surah/1';
 
 export default function Game() {
-  const ayahs = [
-    {
-      words: [
-        { text: "بِسْمِ" },
-        { text: "اللَّهِ" },
-        { text: "الرَّحْمَٰنِ" },
-        { text: "الرَّحِيمِ" },
-      ],
-    },
-    {
-      words: [
-        { text: "الْحَمْدُ" },
-        { text: "لِلَّهِ" },
-        { text: "رَبِّ" },
-        { text: "الْعَالَمِينَ" },
-      ],
-    },
-    {
-      words: [{ text: "الرَّحْمَٰنِ" }, { text: "الرَّحِيمِ" }],
-    },
-    {
-      words: [{ text: "مَٰلِكِ" }, { text: "يَوْمِ" }, { text: "الدِّينِ" }],
-    },
-    {
-      words: [
-        { text: "إِيَّاكَ" },
-        { text: "نَعْبُدُ" },
-        { text: "وَإِيَّاكَ" },
-        { text: "نَسْتَعِينُ" },
-      ],
-    },
-    {
-      words: [
-        { text: "اهْدِنَا" },
-        { text: "الصِّرَاطَ" },
-        { text: "الْمُسْتَقِيمَ" },
-      ],
-    },
-    {
-      words: [
-        { text: "صِرَاطَ" },
-        { text: "الَّذِينَ" },
-        { text: "أَنْعَمْتَ" },
-        { text: "عَلَيْهِمْ" },
-        { text: "غَيْرِ" },
-        { text: "الْمَغْضُوبِ" },
-        { text: "عَلَيْهِمْ" },
-        { text: "وَلَا" },
-        { text: "الضَّآلِّينَ" },
-      ],
-    },
-  ];
+  const ayahs = fatihah.ayahs;
   return (
-    <div>
+    <div dir="rtl" lang="ar">
+      <h1>
+        {fatihah.number}. {fatihah.transliteration} ({fatihah.name})
+      </h1>
       <AyahDisplay ayahs={ayahs}></AyahDisplay>
       <br />
       <Input></Input>

--- a/src/Game/Word.tsx
+++ b/src/Game/Word.tsx
@@ -1,7 +1,8 @@
 export type WordProps = {
   text: string;
+  translation?: string;
 };
 
-export default function Word({ text }: WordProps) {
-  return <span>{text}</span>;
+export default function Word({ text, translation }: WordProps) {
+  return <span title={translation}>{text}</span>;
 }

--- a/src/Game/index.ts
+++ b/src/Game/index.ts
@@ -1,3 +1,3 @@
-import Game from "./Game";
+import Game from './Game';
 
 export default Game;

--- a/src/data/surah/1.ts
+++ b/src/data/surah/1.ts
@@ -1,0 +1,83 @@
+import { SurahData } from '../../types/surah';
+
+export const fatihah: SurahData = {
+  number: 1,
+  name: 'الفاتحة',
+  transliteration: 'Al-Fatihah',
+  translation: 'The Opening',
+  ayahs: [
+    {
+      number: 1,
+      translation:
+        'In the name of Allah, the Entirely Merciful, the Especially Merciful.',
+      words: [
+        { text: 'بِسْمِ', translation: 'In (the) name' },
+        { text: 'اللَّهِ', translation: 'of Allah' },
+        { text: 'الرَّحْمَٰنِ', translation: 'the Most Gracious' },
+        { text: 'الرَّحِيمِ', translation: 'the Most Merciful' },
+      ],
+    },
+    {
+      number: 2,
+      translation: '[All] praise is [due] to Allah, Lord of the worlds -',
+      words: [
+        { text: 'الْحَمْدُ', translation: '[All] praise' },
+        { text: 'لِلَّهِ', translation: '[is] to Allah' },
+        { text: 'رَبِّ', translation: 'Lord' },
+        { text: 'الْعَالَمِينَ', translation: 'of the worlds' },
+      ],
+    },
+    {
+      number: 3,
+      translation: 'The Entirely Merciful, the Especially Merciful,',
+      words: [
+        { text: 'الرَّحْمَٰنِ', translation: 'the Most Gracious' },
+        { text: 'الرَّحِيمِ', translation: 'the Most Merciful' },
+      ],
+    },
+    {
+      number: 4,
+      translation: 'Sovereign of the Day of Recompense.',
+      words: [
+        { text: 'مَٰلِكِ', translation: 'Sovereign' },
+        { text: 'يَوْمِ', translation: 'of (the) Day' },
+        { text: 'الدِّينِ', translation: 'of the Recompense' },
+      ],
+    },
+    {
+      number: 5,
+      translation: 'It is You we worship and You we ask for help.',
+      words: [
+        { text: 'إِيَّاكَ', translation: 'You alone' },
+        { text: 'نَعْبُدُ', translation: 'we worship' },
+        { text: 'وَإِيَّاكَ', translation: 'and You alone' },
+        { text: 'نَسْتَعِينُ', translation: 'we ask for help' },
+      ],
+    },
+    {
+      number: 6,
+      translation: 'Guide us to the straight path -',
+      words: [
+        { text: 'اهْدِنَا', translation: 'Guide us' },
+        { text: 'الصِّرَاطَ', translation: '(to) the path' },
+        { text: 'الْمُسْتَقِيمَ', translation: 'the straight' },
+      ],
+    },
+    {
+      number: 7,
+      translation:
+        'The path of those upon whom You have bestowed favor, not of those who have evoked [Your] anger or of those who are astray.',
+      words: [
+        { text: 'صِرَاطَ', translation: '(The) path' },
+        { text: 'الَّذِينَ', translation: '(of) those' },
+        { text: 'أَنْعَمْتَ', translation: 'You have bestowed favor' },
+        { text: 'عَلَيْهِمْ', translation: 'on them' },
+        { text: 'غَيْرِ', translation: 'not (of)' },
+        { text: 'الْمَغْضُوبِ', translation: 'those who earned (Your) wrath' },
+        { text: 'عَلَيْهِمْ', translation: 'on them' },
+        { text: 'وَلَا', translation: 'and not' },
+        { text: 'الضَّاۤلِّينَ', translation: '(of) those who go astray' },
+      ],
+    },
+  ],
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,13 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family:
+    source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,10 @@
-import React from "react";
-import { createRoot } from "react-dom/client";
-import "./index.css";
-import App from "./App";
-import reportWebVitals from "./reportWebVitals";
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App';
+import reportWebVitals from './reportWebVitals';
 
-const container = document.getElementById("root");
+const container = document.getElementById('root');
 const root = createRoot(container!);
 root.render(
   <React.StrictMode>

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,6 +1,6 @@
 const reportWebVitals = (onPerfEntry?: (metric: any) => void) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import("web-vitals").then(({ onCLS, onFID, onFCP, onLCP, onTTFB }) => {
+    import('web-vitals').then(({ onCLS, onFID, onFCP, onLCP, onTTFB }) => {
       onCLS(onPerfEntry);
       onFID(onPerfEntry);
       onFCP(onPerfEntry);

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import "@testing-library/jest-dom";
+import '@testing-library/jest-dom';

--- a/src/types/surah.ts
+++ b/src/types/surah.ts
@@ -1,0 +1,18 @@
+export interface WordData {
+  text: string;
+  translation: string;
+}
+
+export interface AyahData {
+  number: number;
+  words: WordData[];
+  translation: string;
+}
+
+export interface SurahData {
+  number: number;
+  name: string;
+  transliteration: string;
+  translation: string;
+  ayahs: AyahData[];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5220,6 +5220,11 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-prettier@^9.1.0:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz#90deb4fa0259592df774b600dbd1d2249a78ce91"
+  integrity sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==
+
 eslint-config-react-app@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz#73ba3929978001c5c86274c017ea57eb5fa644b4"
@@ -5390,7 +5395,7 @@ eslint-webpack-plugin@^3.1.1:
     normalize-path "^3.0.0"
     schema-utils "^4.0.0"
 
-eslint@^8.3.0:
+eslint@^8.3.0, eslint@^8.57.1:
   version "8.57.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.1.tgz#7df109654aba7e3bbe5c8eae533c5e461d3c6ca9"
   integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==
@@ -8857,6 +8862,11 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prettier@^3.3.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.3.tgz#560f2de55bf01b4c0503bc629d5df99b9a1d09b0"
+  integrity sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==
 
 pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.6.0"


### PR DESCRIPTION
I have reverted the problematic commit `f9ee17df7da8c5b5020f215a3ab7e9e89565d8bf` and restored the project to its state at `1c4319b`. This restores the missing linter configuration, GitHub Actions workflow, and the data files that were accidentally deleted. I've verified that the linter and formatter now run correctly and pass, and that all tests are successful.

---
*PR created automatically by Jules for task [17017667021575955916](https://jules.google.com/task/17017667021575955916) started by @hashlash*